### PR TITLE
Fixed issue with .NET SDK package clashes when building or installing sample game

### DIFF
--- a/SampleGame/Game/Dockerfile
+++ b/SampleGame/Game/Dockerfile
@@ -5,6 +5,12 @@ WORKDIR /local/game/
 RUN dnf config-manager --add-repo https://download.mono-project.com/repo/centos8-stable.repo
 RUN dnf install -y mono-complete nuget mono-devel
 RUN rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm ;
+RUN awk ' \
+    /^\[amazonlinux\]/ {in_section=1} \
+    /^$/ && in_section {print "excludepkgs=dotnet*,aspnet*,netstandard*"; in_section=0} \
+    {print} \
+    ' /etc/yum.repos.d/amazonlinux.repo > /tmp/temp.repo && \
+    mv /tmp/temp.repo /etc/yum.repos.d/amazonlinux.repo
 RUN dnf install -y dotnet-sdk-7.0 openssl-libs unzip
 RUN curl -O https://gamelift-server-sdk-release.s3.us-west-2.amazonaws.com/csharp/GameLift-CSharp-ServerSDK-5.1.1.zip ;\
 mkdir aws-gamelift-sdk-temp ;\

--- a/SampleGame/Game/install.sh
+++ b/SampleGame/Game/install.sh
@@ -2,6 +2,13 @@
 sudo dnf install -y 'dnf-command(config-manager)'
 
 sudo rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm
+
+sudo awk '
+    /^\[amazonlinux\]/ {in_section=1}
+    /^$/ && in_section {print "excludepkgs=dotnet*,aspnet*,netstandard*"; in_section=0}
+    {print}
+' /etc/yum.repos.d/amazonlinux.repo > temp && sudo mv temp /etc/yum.repos.d/amazonlinux.repo
+
 sudo dnf install -y dotnet-sdk-7.0 openssl-libs unzip
 
 sudo dnf config-manager --add-repo https://download.mono-project.com/repo/centos8-stable.repo


### PR DESCRIPTION
## Description of changes:

Packages for .NET SDK are present in both amazonlinux and microsoft-prod repos which was causing failures when building or installing the sample game. Adding exclusions to /etc/yum.repos.d/amazonlinux.repo for relevant packages so only the microsoft-prod repo is used resolves this issue.