### PR TITLE
fix: upgrade mkdocs-material to >=9.5.32

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,5 +22,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material 
+      - run: pip install "mkdocs-material>=9.5.32" 
       - run: cd docs && mkdocs gh-deploy --force


### PR DESCRIPTION
Upgrades mkdocs-material dependency to >=9.5.32 which includes security improvements.

No functional changes to documentation content or search functionality.