### PR TITLE
ci: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
     env:
       AWS_REGION: eu-west-1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
       - name: Install Lambda dependencies
@@ -44,7 +44,7 @@ jobs:
           mkdir -p ./pr
           echo ${{ github.event.number }}
           echo ${{ github.event.number }} > ./pr/NR
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         name: Upload artifact
         with:
           name: pr

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,8 +21,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - run: pip install 'mkdocs-material>=9.5.32'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Get current date
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
@@ -45,7 +45,7 @@ jobs:
           regex: false
           include: CHANGELOG.md
       - name: Create Release Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: chore:prep release ${{ github.event.inputs.targetRelease }}
           token: ${{ secrets.RELEASE }}


### PR DESCRIPTION
**Issue #, if available:** N/A

## Description of changes:

Updates GitHub Actions workflow action versions to their latest majors to run on the Node.js 24 runtime, resolving Node.js 20 deprecation warnings and preventing future CI breakage.

- actions/checkout v4 → v5 (build, docs, release-prep)
- actions/setup-dotnet v4 → v5 (build)
- actions/upload-artifact v4 → v5 (build)
- actions/setup-python v5 → v6 (docs)
- release-drafter/release-drafter v6 → v7
- peter-evans/create-pull-request v7 → v8 (release-prep)

**Checklist**

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows conventional commit semantics